### PR TITLE
Update Space Coast Tech Events for 2025-09

### DIFF
--- a/src/components/widgets/Announcement.astro
+++ b/src/components/widgets/Announcement.astro
@@ -9,5 +9,5 @@
     class="dark:bg-slate-700 bg-white/40 dark:text-slate-300 font-semibold px-1 py-0.5 text-xs mr-0.5 rtl:mr-0 rtl:ml-0.5 inline-block"
     >NEW</span
   >
-  <a href="/posts/space-coast-tech-events-august-2025">August 2025 Events »</a>
+  <a href="/posts/space-coast-tech-events-september-2025">September 2025 Events »</a>
 </div>

--- a/src/content/post/2025-09-01-space-coast-tech-events-september-2025.mdx
+++ b/src/content/post/2025-09-01-space-coast-tech-events-september-2025.mdx
@@ -1,0 +1,144 @@
+---
+publishDate: 2025-09-01T00:00:00Z
+title: Space Coast Tech Events for September 2025
+excerpt: List of tech events around the Space Coast for September 2025.
+category: Events
+tags:
+  - meetups
+  - events
+slug: space-coast-tech-events-september-2025
+image: ~/assets/images/space-coast-devs-events.png
+---
+
+import CallToAction from '~/components/widgets/CallToAction.astro';
+
+## [AI Hands-On Workshop, Tue, Sep 2, 2025, 7:00 PM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/310511250/?eventOrigin=group_upcoming_events) via [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
+
+Join us for our AI Workshop, where we dive into hands-on projects that bring AI to life!
+
+Each session, we’ll work on activities like:  
+Vibe Coding Apps  
+Using AI in Creative Projects  
+Generate 3D Models to be 3D Printed  
+Generate Images to be Laser Cut
+
+Whether you’re a beginner or experienced, you’ll get the chance to collaborate, create, and explore the endless possibilities of AI in the maker world.
+
+- **Date:** Sep 2
+- **Time:** 7:00 PM
+- **Group:** [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
+
+
+## [Marketing & Sales Acceleration Workshop, Thu, Sep 4, 2025, 4:30 PM](https://www.meetup.com/startupspacecoast/events/310714997/?eventOrigin=group_upcoming_events) via [Groundswell Startups: Space Coast](https://www.meetup.com/startupspacecoast/)
+
+**Marketing & Sales Acceleration Workshop**
+
+Come join us for an exciting day of learning and networking at **Groundswell Startups**! Our workshop is designed to help you supercharge your marketing and sales efforts. Whether you're a seasoned pro or just starting out, this event is perfect for anyone looking to take their business to the next level.
+
+In this workshop, we’ll share how to grab attention without gimmicks, using authentic storytelling that resonates with the heart and drives engagement. Fractional CMO Jenna Buehler and UX & design expert Matt Mayer will share why great design + great narrative = accelerates trust and action.
+
+Don't miss this opportunity to gain valuable insights and strategies from industry experts. Sign up now to secure your spot!
+
+**[RSVP via Eventbrite](https://www.eventbrite.com/e/marketing-sales-acceleration-workshop-tickets-1632043328529?utm-campaign=social&utm-content=attendeeshare&utm-medium=discovery&utm-term=listing&utm-source=cp&aff=ebdsshcopyurl)**
+
+- **Date:** Sep 4
+- **Time:** 4:30 PM
+- **Group:** [Groundswell Startups: Space Coast](https://www.meetup.com/startupspacecoast/)
+
+
+## [Open House: 3D Printing, Thu, Sep 4, 2025, 7:00 PM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/310543335/?eventOrigin=group_upcoming_events) via [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
+
+FREE and open to the public of all ages! This is the time to come and learn how to use the 3D printer; as well as how to obtain or create files to run on them. The 3D printer has a nominal charge of 5 cents per gram for the filament it consumes; but larger projects you may want to obtain 3D filament of your own. Generally, 1 Kgram of 1.75 mm PLA filament is the most common used by many of our members.
+
+- **Date:** Sep 4
+- **Time:** 7:00 PM
+- **Group:** [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
+
+
+## [Open House: Laser Cutting, Thu, Sep 4, 2025, 7:00 PM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/310544281/?eventOrigin=group_upcoming_events) via [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
+
+Want to learn how to use a laser cutter? Have something you need engraved or laser cut? Need to figure out your new tabletop, laser engraver? Check out our open house! It's free and open to the public of all ages!
+
+We use a 100-watt CO2 laser cutter with a Ruida 644XG controller. (More information can be found [here](https://wiki.melbournemakerspace.org/Laser%20Cutter).) It can cut paper, fabric, and up to 1/4" in wood or laser-safe acrylic. There is some scrap material available for use free of charge, but if you have a bigger project, you will need to bring in material to use.
+
+We use Lightburn software to control the laser. It can read most of the standard graphic and vector file types including .bmp, .jpg, .ai, .dxf, and .svg.
+
+- **Date:** Sep 4
+- **Time:** 7:00 PM
+- **Group:** [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
+
+
+## [Open House: Wood Turning, Sat, Sep 6, 2025, 10:00 AM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/310320597/?eventOrigin=group_upcoming_events) via [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
+
+Learn to Turn! Someone will show you how to turn wood safely on a lathe & which tools you should use. You can turn spindles, pens, bowls, or a wide variety of other items. Or do you just want to find out more about the Makerspace (and take a tour)? All you have to do is stop by the open house and ask, and someone will be happy to work with you.  
+The open house is generally unstructured. It has been more effective to work with people 1 on 1. That way people can start, and continue, learning at their own pace.
+
+Original Image provided by Grwoodturning on WikiMedia:  
+[https://commons.wikimedia.org/wiki/File:Bowl\_turning.jpg](https://commons.wikimedia.org/wiki/File:Bowl_turning.jpg)
+
+- **Date:** Sep 6
+- **Time:** 10:00 AM
+- **Group:** [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
+
+
+<CallToAction
+  actions={[
+    {
+      variant: "primary",
+      text: "Join us!",
+      href: "https://www.meetup.com/space-coast-devs/events/310623017/?eventOrigin=group_upcoming_events",
+      target: "_blank",
+      icon: "tabler:brand-meetup",
+    }
+  ]}
+>
+  <Fragment slot="title">
+    [Virtual Coffee, Coding, and Co-working, Tue, Sep 9, 2025, 7:00 PM](https://www.meetup.com/space-coast-devs/events/310623017/?eventOrigin=group_upcoming_events) via [Space Coast Devs](https://www.meetup.com/space-coast-devs/)
+  </Fragment>
+  <Fragment slot="subtitle">
+  Do you have some side project, side hustle, or need to study. Come and hang out with other members and get stuff done!
+  </Fragment>
+</CallToAction>
+
+## [SpaceCoastSec - Crack the Locks, Wed, Sep 10, 2025, 6:30 PM](https://www.meetup.com/spacecoastsec/events/309726384/?eventOrigin=group_upcoming_events) via [SpaceCoastSec - Space Coast's Information Security Community](https://www.meetup.com/spacecoastsec)
+
+Join SpaceCoastSec at 6:30PM EST for an in-person gathering of local cybersecurity professionals, enthusiasts, and curious learners. Each meetup features a speaker discussing a timely infosec topic, as well as open discussion time before and after the presentation for casual banter and friendly networking. Our sessions are informal, inclusive, and completely free—no matter your experience level or background. Come learn, share ideas, ask questions, and stay updated on the latest trends in cybersecurity as part of Brevard County’s growing information security community.
+
+Our monthly in-person meetups are held on the 2nd floor of Building 3 on the EFSC Palm Bay campus unless otherwise stated here on Meetup.
+
+This month's presentation will be on locksport. Locksport is the hobby or sport of learning to open locks without the original key, often through techniques like lock picking. It encompasses the study of lock mechanisms and the ethical practice of defeating them, often involving competitive events and a community of enthusiasts.
+
+- **Date:** Sep 10
+- **Time:** 6:30 PM
+- **Group:** [SpaceCoastSec - Space Coast's Information Security Community](https://www.meetup.com/spacecoastsec)
+
+
+## [Tech Tuesday is BACK, Tue, Sep 23, 2025, 5:30 PM](https://www.meetup.com/startupspacecoast/events/310599778/?eventOrigin=group_upcoming_events) via [Groundswell Startups: Space Coast](https://www.meetup.com/startupspacecoast/)
+
+Meet the local tech and startup community September 23rd for beer, networking and camaraderie.
+
+This event is a great opportunity to meet the Groundswell community, learn about local startup resources, and connect with other tech enthusiasts.
+
+- **Date:** Sep 23
+- **Time:** 5:30 PM
+- **Group:** [Groundswell Startups: Space Coast](https://www.meetup.com/startupspacecoast/)
+
+
+<CallToAction
+  actions={[
+    {
+      variant: "primary",
+      text: "Join us!",
+      href: "https://www.meetup.com/space-coast-devs/events/hsvqrtyhcmbfc/?eventOrigin=group_upcoming_events",
+      target: "_blank",
+      icon: "tabler:brand-meetup",
+    }
+  ]}
+>
+  <Fragment slot="title">
+    [Virtual Coffee, Coding, and Co-working, Tue, Sep 23, 2025, 7:00 PM](https://www.meetup.com/space-coast-devs/events/hsvqrtyhcmbfc/?eventOrigin=group_upcoming_events) via [Space Coast Devs](https://www.meetup.com/space-coast-devs/)
+  </Fragment>
+  <Fragment slot="subtitle">
+  Do you have some side project, side hustle, or need to study. Come and hang out with other members and get stuff done!
+  </Fragment>
+</CallToAction>

--- a/src/content/post/2025-09-01-space-coast-tech-events-september-2025.mdx
+++ b/src/content/post/2025-09-01-space-coast-tech-events-september-2025.mdx
@@ -28,7 +28,6 @@ Whether you’re a beginner or experienced, you’ll get the chance to collabora
 - **Time:** 7:00 PM
 - **Group:** [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
 
-
 ## [Marketing & Sales Acceleration Workshop, Thu, Sep 4, 2025, 4:30 PM](https://www.meetup.com/startupspacecoast/events/310714997/?eventOrigin=group_upcoming_events) via [Groundswell Startups: Space Coast](https://www.meetup.com/startupspacecoast/)
 
 **Marketing & Sales Acceleration Workshop**
@@ -45,7 +44,6 @@ Don't miss this opportunity to gain valuable insights and strategies from indust
 - **Time:** 4:30 PM
 - **Group:** [Groundswell Startups: Space Coast](https://www.meetup.com/startupspacecoast/)
 
-
 ## [Open House: 3D Printing, Thu, Sep 4, 2025, 7:00 PM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/310543335/?eventOrigin=group_upcoming_events) via [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
 
 FREE and open to the public of all ages! This is the time to come and learn how to use the 3D printer; as well as how to obtain or create files to run on them. The 3D printer has a nominal charge of 5 cents per gram for the filament it consumes; but larger projects you may want to obtain 3D filament of your own. Generally, 1 Kgram of 1.75 mm PLA filament is the most common used by many of our members.
@@ -53,7 +51,6 @@ FREE and open to the public of all ages! This is the time to come and learn how 
 - **Date:** Sep 4
 - **Time:** 7:00 PM
 - **Group:** [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
-
 
 ## [Open House: Laser Cutting, Thu, Sep 4, 2025, 7:00 PM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/310544281/?eventOrigin=group_upcoming_events) via [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
 
@@ -67,36 +64,37 @@ We use Lightburn software to control the laser. It can read most of the standard
 - **Time:** 7:00 PM
 - **Group:** [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
 
-
 ## [Open House: Wood Turning, Sat, Sep 6, 2025, 10:00 AM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/310320597/?eventOrigin=group_upcoming_events) via [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
 
 Learn to Turn! Someone will show you how to turn wood safely on a lathe & which tools you should use. You can turn spindles, pens, bowls, or a wide variety of other items. Or do you just want to find out more about the Makerspace (and take a tour)? All you have to do is stop by the open house and ask, and someone will be happy to work with you.  
 The open house is generally unstructured. It has been more effective to work with people 1 on 1. That way people can start, and continue, learning at their own pace.
 
 Original Image provided by Grwoodturning on WikiMedia:  
-[https://commons.wikimedia.org/wiki/File:Bowl\_turning.jpg](https://commons.wikimedia.org/wiki/File:Bowl_turning.jpg)
+[https://commons.wikimedia.org/wiki/File:Bowl_turning.jpg](https://commons.wikimedia.org/wiki/File:Bowl_turning.jpg)
 
 - **Date:** Sep 6
 - **Time:** 10:00 AM
 - **Group:** [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
 
-
 <CallToAction
   actions={[
     {
-      variant: "primary",
-      text: "Join us!",
-      href: "https://www.meetup.com/space-coast-devs/events/310623017/?eventOrigin=group_upcoming_events",
-      target: "_blank",
-      icon: "tabler:brand-meetup",
-    }
+      variant: 'primary',
+      text: 'Join us!',
+      href: 'https://www.meetup.com/space-coast-devs/events/310623017/?eventOrigin=group_upcoming_events',
+      target: '_blank',
+      icon: 'tabler:brand-meetup',
+    },
   ]}
 >
   <Fragment slot="title">
-    [Virtual Coffee, Coding, and Co-working, Tue, Sep 9, 2025, 7:00 PM](https://www.meetup.com/space-coast-devs/events/310623017/?eventOrigin=group_upcoming_events) via [Space Coast Devs](https://www.meetup.com/space-coast-devs/)
+    [Virtual Coffee, Coding, and Co-working, Tue, Sep 9, 2025, 7:00
+    PM](https://www.meetup.com/space-coast-devs/events/310623017/?eventOrigin=group_upcoming_events) via [Space Coast
+    Devs](https://www.meetup.com/space-coast-devs/)
   </Fragment>
   <Fragment slot="subtitle">
-  Do you have some side project, side hustle, or need to study. Come and hang out with other members and get stuff done!
+    Do you have some side project, side hustle, or need to study. Come and hang out with other members and get stuff
+    done!
   </Fragment>
 </CallToAction>
 
@@ -112,7 +110,6 @@ This month's presentation will be on locksport. Locksport is the hobby or sport 
 - **Time:** 6:30 PM
 - **Group:** [SpaceCoastSec - Space Coast's Information Security Community](https://www.meetup.com/spacecoastsec)
 
-
 ## [Tech Tuesday is BACK, Tue, Sep 23, 2025, 5:30 PM](https://www.meetup.com/startupspacecoast/events/310599778/?eventOrigin=group_upcoming_events) via [Groundswell Startups: Space Coast](https://www.meetup.com/startupspacecoast/)
 
 Meet the local tech and startup community September 23rd for beer, networking and camaraderie.
@@ -123,22 +120,24 @@ This event is a great opportunity to meet the Groundswell community, learn about
 - **Time:** 5:30 PM
 - **Group:** [Groundswell Startups: Space Coast](https://www.meetup.com/startupspacecoast/)
 
-
 <CallToAction
   actions={[
     {
-      variant: "primary",
-      text: "Join us!",
-      href: "https://www.meetup.com/space-coast-devs/events/hsvqrtyhcmbfc/?eventOrigin=group_upcoming_events",
-      target: "_blank",
-      icon: "tabler:brand-meetup",
-    }
+      variant: 'primary',
+      text: 'Join us!',
+      href: 'https://www.meetup.com/space-coast-devs/events/hsvqrtyhcmbfc/?eventOrigin=group_upcoming_events',
+      target: '_blank',
+      icon: 'tabler:brand-meetup',
+    },
   ]}
 >
   <Fragment slot="title">
-    [Virtual Coffee, Coding, and Co-working, Tue, Sep 23, 2025, 7:00 PM](https://www.meetup.com/space-coast-devs/events/hsvqrtyhcmbfc/?eventOrigin=group_upcoming_events) via [Space Coast Devs](https://www.meetup.com/space-coast-devs/)
+    [Virtual Coffee, Coding, and Co-working, Tue, Sep 23, 2025, 7:00
+    PM](https://www.meetup.com/space-coast-devs/events/hsvqrtyhcmbfc/?eventOrigin=group_upcoming_events) via [Space
+    Coast Devs](https://www.meetup.com/space-coast-devs/)
   </Fragment>
   <Fragment slot="subtitle">
-  Do you have some side project, side hustle, or need to study. Come and hang out with other members and get stuff done!
+    Do you have some side project, side hustle, or need to study. Come and hang out with other members and get stuff
+    done!
   </Fragment>
 </CallToAction>


### PR DESCRIPTION
## 🤖 Automated Event Update for 2025-09

This PR contains an automated update of the Space Coast tech events markdown file.

### 📊 Summary
- **Total Events**: 9
- **Period**: 2025-09
- **Generated**: 9/1/2025, 10:07:51 PM ET

### 📅 Events by Group
- **Melbourne Makerspace (Florida USA)**: 4 events
- **Groundswell Startups: Space Coast**: 2 events
- **Space Coast Devs**: 2 events
- **SpaceCoastSec - Space Coast's Information Security Community**: 1 event

### 🔄 Changes
- Updated event listings from Meetup groups
- Events filtered for 2025-09
- Markdown formatted for Astro site integration
- Sorted chronologically by event date

### 🌐 Source Groups
- [Space Coast Devs](https://www.meetup.com/space-coast-devs/)
- [Space Coast Security](https://www.meetup.com/spacecoastsec)
- [Melbourne Makerspace](https://www.meetup.com/melbourne-makerspace-florida-usa/)
- [Melbourne R/H User Group](https://www.meetup.com/melbourne-rhug)
- [Startup Space Coast](https://www.meetup.com/startupspacecoast/)

*This PR was created automatically by the evnt-hndlr tool. Please review the content before merging.*