### PR TITLE
Update Space Coast Tech Events for 2025-10

### DIFF
--- a/src/components/widgets/Announcement.astro
+++ b/src/components/widgets/Announcement.astro
@@ -9,5 +9,5 @@
     class="dark:bg-slate-700 bg-white/40 dark:text-slate-300 font-semibold px-1 py-0.5 text-xs mr-0.5 rtl:mr-0 rtl:ml-0.5 inline-block"
     >NEW</span
   >
-  <a href="/posts/space-coast-tech-events-september-2025">September 2025 Events »</a>
+  <a href="/posts/space-coast-tech-events-october-2025">October 2025 Events »</a>
 </div>

--- a/src/content/post/2025-10-03-space-coast-tech-events-october-2025.mdx
+++ b/src/content/post/2025-10-03-space-coast-tech-events-october-2025.mdx
@@ -1,0 +1,255 @@
+---
+publishDate: 2025-10-03T00:00:00Z
+title: Space Coast Tech Events for October 2025
+excerpt: List of tech events around the Space Coast for October 2025.
+category: Events
+tags:
+  - meetups
+  - events
+slug: space-coast-tech-events-october-2025
+image: ~/assets/images/space-coast-devs-events.png
+---
+
+import CallToAction from '~/components/widgets/CallToAction.astro';
+
+## [Open House: Laser Cutting, Thu, Oct 2, 2025, 7:00 PM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/311014150/?eventOrigin=group_past_events) via [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
+
+Want to learn how to use a laser cutter? Have something you need engraved or laser cut? Need to figure out your new tabletop, laser engraver? Check out our open house! It's free and open to the public of all ages!
+
+We use a 100-watt CO2 laser cutter with a Ruida 644XG controller. (More information can be found [here](https://wiki.melbournemakerspace.org/Laser%20Cutter).) It can cut paper, fabric, and up to 1/4" in wood or laser-safe acrylic. There is some scrap material available for use free of charge, but if you have a bigger project, you will need to bring in material to use.
+
+We use Lightburn software to control the laser. It can read most of the standard graphic and vector file types including .bmp, .jpg, .ai, .dxf, and .svg.
+
+- **Date:** Oct 2
+- **Time:** 7:00 PM
+- **Group:** [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
+
+
+## [Open House: 3D Printing, Thu, Oct 2, 2025, 7:00 PM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/311013210/?eventOrigin=group_past_events) via [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
+
+FREE and open to the public of all ages! This is the time to come and learn how to use the 3D printer; as well as how to obtain or create files to run on them. The 3D printer has a nominal charge of 5 cents per gram for the filament it consumes; but larger projects you may want to obtain 3D filament of your own. Generally, 1 Kgram of 1.75 mm PLA filament is the most common used by many of our members.
+
+- **Date:** Oct 2
+- **Time:** 7:00 PM
+- **Group:** [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
+
+
+## [Open House: Wood Turning, Sat, Oct 4, 2025, 10:00 AM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/310727521/?eventOrigin=group_upcoming_events) via [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
+
+Learn to Turn! Someone will show you how to turn wood safely on a lathe & which tools you should use. You can turn spindles, pens, bowls, or a wide variety of other items. Or do you just want to find out more about the Makerspace (and take a tour)? All you have to do is stop by the open house and ask, and someone will be happy to work with you.  
+The open house is generally unstructured. It has been more effective to work with people 1 on 1. That way people can start, and continue, learning at their own pace.
+
+Original Image provided by Grwoodturning on WikiMedia:  
+[https://commons.wikimedia.org/wiki/File:Bowl\_turning.jpg](https://commons.wikimedia.org/wiki/File:Bowl_turning.jpg)
+
+- **Date:** Oct 4
+- **Time:** 10:00 AM
+- **Group:** [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
+
+
+## [Open House: Electronics Projects and Programming, Sat, Oct 4, 2025, 10:00 AM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/311036914/?eventOrigin=group_upcoming_events) via [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
+
+Want to learn basic electronics? Interested in working with a microcontroller, like the arduino, ESP32, or the Raspberry Pi Pico? Need help designing your own PCB? Want to learn to program in Python? Or do you just want to find out more about the Makerspace (and take a tour)? All you have to do is stop by the open house and ask, and someone will be happy to work with you.
+
+The open house is generally unstructured. It has been more effective to work with people 1 on 1. That way people can start, and continue, learning at their own pace.
+
+(Picture courtesy of Wikimedia Commons)
+
+- **Date:** Oct 4
+- **Time:** 10:00 AM
+- **Group:** [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
+
+
+## [RSVP to the Red Hat User Group at IBM TechXchange Orlando! , Mon, Oct 6, 2025, 3:00 PM](https://www.meetup.com/melbourne-rhug/events/310411559/?eventOrigin=group_upcoming_events) via [Melbourne Red Hat User Group](https://www.meetup.com/melbourne-rhug)
+
+Registration options and instructions below- meetup RSVP will not count as registered for this event.
+
+1.  Attend The Red Hat® User Group AND IBM TechXchange 2025
+2.  Please register via this link below [https://reg.tools.ibm.com/flow/ibm/techxchange25/reg?regcode=30redhatusergroup](https://reg.tools.ibm.com/flow/ibm/techxchange25/reg?regcode=30redhatusergroup)
+3.  Attend The Red Hat® User Group AND Community Day only on October 6
+4.  Please register via this link below [https://reg.tools.ibm.com/flow/ibm/techxchange25/reg?regcode=FreeComDayredhatusergroup](https://reg.tools.ibm.com/flow/ibm/techxchange25/reg?regcode=FreeComDayredhatusergroup)
+
+**OVERVIEW**  
+Join Red Hat® at the IBM TechXchange in Orlando, Florida on October 6 for a Red Hat® User Group (RHUG). Hosted during the Community Day portion of the event, this session offers a unique opportunity to network and explore cutting-edge solutions for IT modernization.
+
+Unfamiliar with RHUGs? This type of event offers a unique opportunity for Red Hat technology users–regardless of skill level–to gather and discover solutions to IT challenges with subject matter experts and peers.
+
+Join us on Community Day at the IBM TechXchange to connect with the RHUG community and explore how to transform your IT services over good food and drink.
+
+**Agenda:**  
+Title: Scalable, Cost-Efficient AI with IBM [watsonx.ai](http://watsonx.ai) and Red Hat OpenShift AI
+
+IBM [watsonx.ai](http://watsonx.ai) is an AI development studio for building and deploying both traditional and generative AI models. Running on Red Hat OpenShift AI (RHOAI), it benefits from scalable infrastructure, GPU orchestration, and robust model serving in hybrid environments.
+
+Together, they streamline the AI lifecycle while cutting inference costs through features like model quantization, GPU sharing, and autoscaling. This integration empowers teams to deliver secure, high-performance AI solutions—faster and more efficiently.
+
+Event Details:  
+Date: October 6, 2025  
+Time: 3:00 PM - 5:00 PM ET  
+Location: Orange County Convention Center- room TBD
+
+Registration options and instructions
+
+1.  Attend The Red Hat® User Group AND IBM TechXchange 2025
+2.  Please register via this link below [https://reg.tools.ibm.com/flow/ibm/techxchange25/reg?regcode=30redhatusergroup](https://reg.tools.ibm.com/flow/ibm/techxchange25/reg?regcode=30redhatusergroup)
+3.  Attend The Red Hat® User Group AND Community Day only on October 6
+4.  Please register via this link below [https://reg.tools.ibm.com/flow/ibm/techxchange25/reg?regcode=FreeComDayredhatusergroup](https://reg.tools.ibm.com/flow/ibm/techxchange25/reg?regcode=FreeComDayredhatusergroup)
+
+- **Date:** Oct 6
+- **Time:** 3:00 PM
+- **Group:** [Melbourne Red Hat User Group](https://www.meetup.com/melbourne-rhug)
+
+
+## [Wood Shop, Mon, Oct 6, 2025, 7:00 PM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/310727522/?eventOrigin=group_upcoming_events) via [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
+
+Free and open to the public! This is the time to come and learn woodworking, power tools like the band saw, table saw, drill press, sanders, etc. We even have a CNC! Want to fix a broken table leg? Build a shelf? Build a bird or bat house? Work on these projects and anything you imagine every week!
+
+Drop in a take a tour of the Makerspace to see what it's all about.
+
+- **Date:** Oct 6
+- **Time:** 7:00 PM
+- **Group:** [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
+
+
+## [Pottery, Mon, Oct 6, 2025, 7:00 PM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/310727523/?eventOrigin=group_upcoming_events) via [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
+
+Free and open to the public, kids and adults! This is the time to come and develop your creative skills among friends. We've got tools and volunteers to help with all kinds of arts and crafts. Here are a few to get you thinking about what you'd like to try:
+
+-   Pottery - Hand built, Slab rolling, or Wheel thrown
+-   Sewing - Embroidery, Serger, Quilting
+-   Painting - Acrylic, Water color, Oil
+-   Card Making
+-   Jewelry
+-   Origami
+-   Yarn - Knit or Crochet
+
+Bring in a project you're working on or an idea of what you'd like to try and we'll do what we can to help bring it to life.  
+Lately, we've been spending most of the open house in the pottery studio and above are some of our creations.
+
+- **Date:** Oct 6
+- **Time:** 7:00 PM
+- **Group:** [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
+
+
+<CallToAction
+  actions={[
+    {
+      variant: "primary",
+      text: "Join us!",
+      href: "https://www.meetup.com/space-coast-devs/events/311096292/?eventOrigin=group_upcoming_events",
+      target: "_blank",
+      icon: "tabler:brand-meetup",
+    }
+  ]}
+>
+  <Fragment slot="title">
+    [Virtual Coding and Co-working, Tue, Oct 7, 2025, 8:00 PM](https://www.meetup.com/space-coast-devs/events/311096292/?eventOrigin=group_upcoming_events) via [Space Coast Devs](https://www.meetup.com/space-coast-devs/)
+  </Fragment>
+  <Fragment slot="subtitle">
+  Do you have a side project, side hustle, or need to study. Come and hang out with other members and get stuff done!
+  </Fragment>
+</CallToAction>
+
+## [Hack The Box Meetup #4, Wed, Oct 15, 2025, 6:30 PM](https://www.meetup.com/spacecoastsec/events/309726395/?eventOrigin=group_upcoming_events) via [SpaceCoastSec - Space Coast's Information Security Community](https://www.meetup.com/spacecoastsec)
+
+📣 Registration is open for Hack The Box Meetup #4! 🎉
+
+We’re excited to announce the fourth Melbourne Hack The Box Meetup!
+
+📃 Register here: [https://www.meetup.com/hack-the-box-meetup-melbourne-fl-us/events/310989752](https://www.meetup.com/hack-the-box-meetup-melbourne-fl-us/events/310989752)  
+🗓 Date: Wednesday, October 15th  
+🕓 Time: 6:30PM Eastern. We will wrap at 8:30PM Eastern.  
+📍 Where: EFSC, Palm Bay. Building 3, Cyber Lab
+
+Whether you're experienced or not, you’re welcome to join us! This is our fourth event, and we're to work on the foundations. We will work on one or more pathways on the HTB platform. Beginners are welcome! Again, no experience necessary, just bring your curiosity.
+
+🛑 IMPORTANT:
+
+To attend, you must register on the Hack the Box Melbourne, FL Meetup:  
+👉 [https://www.meetup.com/hack-the-box-meetup-melbourne-fl-us/events/310989752](https://www.meetup.com/hack-the-box-meetup-melbourne-fl-us/events/310989752)
+
+📌 RSVPs on [Meetup.com](http://Meetup.com) are how Hack The Box measures the success of our community, so please help us out by signing up as soon as it’s published!
+
+💡 It’s fine to use a fake name or throwaway email for [Meetup.com,](http://Meetup.com,) but when registering for the event, you’ll be asked for the real email address you use with Hack The Box.
+
+Let's show Hack The Box that we can bring out a huge crowd.
+
+Hope to see all of you soon! 🚀
+
+- **Date:** Oct 15
+- **Time:** 6:30 PM
+- **Group:** [SpaceCoastSec - Space Coast's Information Security Community](https://www.meetup.com/spacecoastsec)
+
+
+## [RSVP to the next Melbourne, FL  Red Hat User Group , Thu, Oct 16, 2025, 5:00 PM](https://www.meetup.com/melbourne-rhug/events/310765684/?eventOrigin=group_upcoming_events) via [Melbourne Red Hat User Group](https://www.meetup.com/melbourne-rhug)
+
+RSVP here: **[https://events.redhat.com/profile/form/index.cfm?PKformID=0x1526024abcd&sc\_cid=RHCTN1250000459960](https://events.redhat.com/profile/form/index.cfm?PKformID=0x1526024abcd&sc_cid=RHCTN1250000459960)**
+
+Innovation in the aerospace IT industry often comes with unique and formidable requirements. That's why we invite you to the upcoming Red Hat User Group (RHUG) in Melbourne, designed to help you navigate these challenges and propel your IT modernization efforts forward.
+
+At this RHUG event, you'll gain practical insights into leveraging Red Hat OpenShift to build compliant, scalable container platforms across multiple, segmented networks. This is your chance to learn directly from experts and peers about:
+
+-   Best practices for deploying Red Hat OpenShift in complex, highly controlled network environments.
+-   Strategies for developing security-focused container platforms that adhere to rigorous aerospace and defense compliance standards.
+-   How to innovate effectively within restricted environments while maintaining stringent security protocols.
+
+This is more than just a presentation; it's an opportunity to network with fellow professionals, exchange ideas, and discover solutions that can genuinely transform your IT services. Plus, we'll provide delicious food and drinks to fuel our discussions.
+
+Mark Your Calendar:
+
+-   Date: Thursday, October 16, 2025
+-   Time: 5:00 PM – 8:00 PM ET
+-   Location: One Oak, 1800 W Hibiscus Blvd #108, Melbourne, FL 32901
+
+Secure your spot today and take the next step in optimizing your IT infrastructure.
+
+For any inquiries, please contact [rhug@redhat.com.](http://rhug@redhat.com.)
+
+- **Date:** Oct 16
+- **Time:** 5:00 PM
+- **Group:** [Melbourne Red Hat User Group](https://www.meetup.com/melbourne-rhug)
+
+
+<CallToAction
+  actions={[
+    {
+      variant: "primary",
+      text: "Join us!",
+      href: "https://www.meetup.com/space-coast-devs/events/311333450/?eventOrigin=group_upcoming_events",
+      target: "_blank",
+      icon: "tabler:brand-meetup",
+    }
+  ]}
+>
+  <Fragment slot="title">
+    [Virtual Coding and Co-working, Tue, Oct 21, 2025, 8:00 PM](https://www.meetup.com/space-coast-devs/events/311333450/?eventOrigin=group_upcoming_events) via [Space Coast Devs](https://www.meetup.com/space-coast-devs/)
+  </Fragment>
+  <Fragment slot="subtitle">
+  Do you have a side project, side hustle, or need to study. Come and hang out with other members and get stuff done!
+  </Fragment>
+</CallToAction>
+
+## [RSTCON, Fri, Oct 24, 2025, 12:00 PM](https://www.meetup.com/spacecoastsec/events/310990724/?eventOrigin=group_upcoming_events) via [SpaceCoastSec - Space Coast's Information Security Community](https://www.meetup.com/spacecoastsec)
+
+We are attending RSTCON in Savannah, GA this year.
+
+Come find us and say hi!
+
+[https://rstcon.org/](https://rstcon.org/)
+
+- **Date:** Oct 24
+- **Time:** 12:00 PM
+- **Group:** [SpaceCoastSec - Space Coast's Information Security Community](https://www.meetup.com/spacecoastsec)
+
+
+## [Sprint Speedrun: A Maker Jam Series, Sat, Oct 25, 2025, 11:00 AM](https://www.meetup.com/startupspacecoast/events/311309700/?eventOrigin=group_upcoming_events) via [Groundswell Startups: Space Coast](https://www.meetup.com/startupspacecoast/)
+
+Saturday, October 25th - join us for a mad dash to prototype in this new event series. Teams (formed at the event) will choose a prompt from real, local startups to solve and build for.
+
+Prototypes can be sketches, software, or design and will be presented to our panel of judges at the end of the day - with a winner chosen and awarded with a unique badge.
+
+This event is casual and intended to be an opportunity for tech and startup enthusiasts to stretch their rapid prototyping muscles and participate in a pseudo-sprint solving real problems. No specific experience necessary, but join ready to build and fail and build again!
+
+- **Date:** Oct 25
+- **Time:** 11:00 AM
+- **Group:** [Groundswell Startups: Space Coast](https://www.meetup.com/startupspacecoast/)

--- a/src/content/post/2025-10-03-space-coast-tech-events-october-2025.mdx
+++ b/src/content/post/2025-10-03-space-coast-tech-events-october-2025.mdx
@@ -24,7 +24,6 @@ We use Lightburn software to control the laser. It can read most of the standard
 - **Time:** 7:00 PM
 - **Group:** [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
 
-
 ## [Open House: 3D Printing, Thu, Oct 2, 2025, 7:00 PM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/311013210/?eventOrigin=group_past_events) via [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
 
 FREE and open to the public of all ages! This is the time to come and learn how to use the 3D printer; as well as how to obtain or create files to run on them. The 3D printer has a nominal charge of 5 cents per gram for the filament it consumes; but larger projects you may want to obtain 3D filament of your own. Generally, 1 Kgram of 1.75 mm PLA filament is the most common used by many of our members.
@@ -33,19 +32,17 @@ FREE and open to the public of all ages! This is the time to come and learn how 
 - **Time:** 7:00 PM
 - **Group:** [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
 
-
 ## [Open House: Wood Turning, Sat, Oct 4, 2025, 10:00 AM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/310727521/?eventOrigin=group_upcoming_events) via [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
 
 Learn to Turn! Someone will show you how to turn wood safely on a lathe & which tools you should use. You can turn spindles, pens, bowls, or a wide variety of other items. Or do you just want to find out more about the Makerspace (and take a tour)? All you have to do is stop by the open house and ask, and someone will be happy to work with you.  
 The open house is generally unstructured. It has been more effective to work with people 1 on 1. That way people can start, and continue, learning at their own pace.
 
 Original Image provided by Grwoodturning on WikiMedia:  
-[https://commons.wikimedia.org/wiki/File:Bowl\_turning.jpg](https://commons.wikimedia.org/wiki/File:Bowl_turning.jpg)
+[https://commons.wikimedia.org/wiki/File:Bowl_turning.jpg](https://commons.wikimedia.org/wiki/File:Bowl_turning.jpg)
 
 - **Date:** Oct 4
 - **Time:** 10:00 AM
 - **Group:** [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
-
 
 ## [Open House: Electronics Projects and Programming, Sat, Oct 4, 2025, 10:00 AM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/311036914/?eventOrigin=group_upcoming_events) via [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
 
@@ -58,7 +55,6 @@ The open house is generally unstructured. It has been more effective to work wit
 - **Date:** Oct 4
 - **Time:** 10:00 AM
 - **Group:** [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
-
 
 ## [RSVP to the Red Hat User Group at IBM TechXchange Orlando! , Mon, Oct 6, 2025, 3:00 PM](https://www.meetup.com/melbourne-rhug/events/310411559/?eventOrigin=group_upcoming_events) via [Melbourne Red Hat User Group](https://www.meetup.com/melbourne-rhug)
 
@@ -99,7 +95,6 @@ Registration options and instructions
 - **Time:** 3:00 PM
 - **Group:** [Melbourne Red Hat User Group](https://www.meetup.com/melbourne-rhug)
 
-
 ## [Wood Shop, Mon, Oct 6, 2025, 7:00 PM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/310727522/?eventOrigin=group_upcoming_events) via [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
 
 Free and open to the public! This is the time to come and learn woodworking, power tools like the band saw, table saw, drill press, sanders, etc. We even have a CNC! Want to fix a broken table leg? Build a shelf? Build a bird or bat house? Work on these projects and anything you imagine every week!
@@ -110,18 +105,17 @@ Drop in a take a tour of the Makerspace to see what it's all about.
 - **Time:** 7:00 PM
 - **Group:** [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
 
-
 ## [Pottery, Mon, Oct 6, 2025, 7:00 PM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/310727523/?eventOrigin=group_upcoming_events) via [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
 
 Free and open to the public, kids and adults! This is the time to come and develop your creative skills among friends. We've got tools and volunteers to help with all kinds of arts and crafts. Here are a few to get you thinking about what you'd like to try:
 
--   Pottery - Hand built, Slab rolling, or Wheel thrown
--   Sewing - Embroidery, Serger, Quilting
--   Painting - Acrylic, Water color, Oil
--   Card Making
--   Jewelry
--   Origami
--   Yarn - Knit or Crochet
+- Pottery - Hand built, Slab rolling, or Wheel thrown
+- Sewing - Embroidery, Serger, Quilting
+- Painting - Acrylic, Water color, Oil
+- Card Making
+- Jewelry
+- Origami
+- Yarn - Knit or Crochet
 
 Bring in a project you're working on or an idea of what you'd like to try and we'll do what we can to help bring it to life.  
 Lately, we've been spending most of the open house in the pottery studio and above are some of our creations.
@@ -130,23 +124,24 @@ Lately, we've been spending most of the open house in the pottery studio and abo
 - **Time:** 7:00 PM
 - **Group:** [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
 
-
 <CallToAction
   actions={[
     {
-      variant: "primary",
-      text: "Join us!",
-      href: "https://www.meetup.com/space-coast-devs/events/311096292/?eventOrigin=group_upcoming_events",
-      target: "_blank",
-      icon: "tabler:brand-meetup",
-    }
+      variant: 'primary',
+      text: 'Join us!',
+      href: 'https://www.meetup.com/space-coast-devs/events/311096292/?eventOrigin=group_upcoming_events',
+      target: '_blank',
+      icon: 'tabler:brand-meetup',
+    },
   ]}
 >
   <Fragment slot="title">
-    [Virtual Coding and Co-working, Tue, Oct 7, 2025, 8:00 PM](https://www.meetup.com/space-coast-devs/events/311096292/?eventOrigin=group_upcoming_events) via [Space Coast Devs](https://www.meetup.com/space-coast-devs/)
+    [Virtual Coding and Co-working, Tue, Oct 7, 2025, 8:00
+    PM](https://www.meetup.com/space-coast-devs/events/311096292/?eventOrigin=group_upcoming_events) via [Space Coast
+    Devs](https://www.meetup.com/space-coast-devs/)
   </Fragment>
   <Fragment slot="subtitle">
-  Do you have a side project, side hustle, or need to study. Come and hang out with other members and get stuff done!
+    Do you have a side project, side hustle, or need to study. Come and hang out with other members and get stuff done!
   </Fragment>
 </CallToAction>
 
@@ -180,26 +175,25 @@ Hope to see all of you soon! 🚀
 - **Time:** 6:30 PM
 - **Group:** [SpaceCoastSec - Space Coast's Information Security Community](https://www.meetup.com/spacecoastsec)
 
+## [RSVP to the next Melbourne, FL Red Hat User Group , Thu, Oct 16, 2025, 5:00 PM](https://www.meetup.com/melbourne-rhug/events/310765684/?eventOrigin=group_upcoming_events) via [Melbourne Red Hat User Group](https://www.meetup.com/melbourne-rhug)
 
-## [RSVP to the next Melbourne, FL  Red Hat User Group , Thu, Oct 16, 2025, 5:00 PM](https://www.meetup.com/melbourne-rhug/events/310765684/?eventOrigin=group_upcoming_events) via [Melbourne Red Hat User Group](https://www.meetup.com/melbourne-rhug)
-
-RSVP here: **[https://events.redhat.com/profile/form/index.cfm?PKformID=0x1526024abcd&sc\_cid=RHCTN1250000459960](https://events.redhat.com/profile/form/index.cfm?PKformID=0x1526024abcd&sc_cid=RHCTN1250000459960)**
+RSVP here: **[https://events.redhat.com/profile/form/index.cfm?PKformID=0x1526024abcd&sc_cid=RHCTN1250000459960](https://events.redhat.com/profile/form/index.cfm?PKformID=0x1526024abcd&sc_cid=RHCTN1250000459960)**
 
 Innovation in the aerospace IT industry often comes with unique and formidable requirements. That's why we invite you to the upcoming Red Hat User Group (RHUG) in Melbourne, designed to help you navigate these challenges and propel your IT modernization efforts forward.
 
 At this RHUG event, you'll gain practical insights into leveraging Red Hat OpenShift to build compliant, scalable container platforms across multiple, segmented networks. This is your chance to learn directly from experts and peers about:
 
--   Best practices for deploying Red Hat OpenShift in complex, highly controlled network environments.
--   Strategies for developing security-focused container platforms that adhere to rigorous aerospace and defense compliance standards.
--   How to innovate effectively within restricted environments while maintaining stringent security protocols.
+- Best practices for deploying Red Hat OpenShift in complex, highly controlled network environments.
+- Strategies for developing security-focused container platforms that adhere to rigorous aerospace and defense compliance standards.
+- How to innovate effectively within restricted environments while maintaining stringent security protocols.
 
 This is more than just a presentation; it's an opportunity to network with fellow professionals, exchange ideas, and discover solutions that can genuinely transform your IT services. Plus, we'll provide delicious food and drinks to fuel our discussions.
 
 Mark Your Calendar:
 
--   Date: Thursday, October 16, 2025
--   Time: 5:00 PM – 8:00 PM ET
--   Location: One Oak, 1800 W Hibiscus Blvd #108, Melbourne, FL 32901
+- Date: Thursday, October 16, 2025
+- Time: 5:00 PM – 8:00 PM ET
+- Location: One Oak, 1800 W Hibiscus Blvd #108, Melbourne, FL 32901
 
 Secure your spot today and take the next step in optimizing your IT infrastructure.
 
@@ -209,23 +203,24 @@ For any inquiries, please contact [rhug@redhat.com.](http://rhug@redhat.com.)
 - **Time:** 5:00 PM
 - **Group:** [Melbourne Red Hat User Group](https://www.meetup.com/melbourne-rhug)
 
-
 <CallToAction
   actions={[
     {
-      variant: "primary",
-      text: "Join us!",
-      href: "https://www.meetup.com/space-coast-devs/events/311333450/?eventOrigin=group_upcoming_events",
-      target: "_blank",
-      icon: "tabler:brand-meetup",
-    }
+      variant: 'primary',
+      text: 'Join us!',
+      href: 'https://www.meetup.com/space-coast-devs/events/311333450/?eventOrigin=group_upcoming_events',
+      target: '_blank',
+      icon: 'tabler:brand-meetup',
+    },
   ]}
 >
   <Fragment slot="title">
-    [Virtual Coding and Co-working, Tue, Oct 21, 2025, 8:00 PM](https://www.meetup.com/space-coast-devs/events/311333450/?eventOrigin=group_upcoming_events) via [Space Coast Devs](https://www.meetup.com/space-coast-devs/)
+    [Virtual Coding and Co-working, Tue, Oct 21, 2025, 8:00
+    PM](https://www.meetup.com/space-coast-devs/events/311333450/?eventOrigin=group_upcoming_events) via [Space Coast
+    Devs](https://www.meetup.com/space-coast-devs/)
   </Fragment>
   <Fragment slot="subtitle">
-  Do you have a side project, side hustle, or need to study. Come and hang out with other members and get stuff done!
+    Do you have a side project, side hustle, or need to study. Come and hang out with other members and get stuff done!
   </Fragment>
 </CallToAction>
 
@@ -240,7 +235,6 @@ Come find us and say hi!
 - **Date:** Oct 24
 - **Time:** 12:00 PM
 - **Group:** [SpaceCoastSec - Space Coast's Information Security Community](https://www.meetup.com/spacecoastsec)
-
 
 ## [Sprint Speedrun: A Maker Jam Series, Sat, Oct 25, 2025, 11:00 AM](https://www.meetup.com/startupspacecoast/events/311309700/?eventOrigin=group_upcoming_events) via [Groundswell Startups: Space Coast](https://www.meetup.com/startupspacecoast/)
 


### PR DESCRIPTION
## 🤖 Automated Event Update for 2025-10

This PR contains an automated update of the Space Coast tech events markdown file.

### 📊 Summary
- **Total Events**: 13
- **Period**: 2025-10
- **Generated**: 10/3/2025, 11:55:11 AM ET

### 📅 Events by Group
- **Melbourne Makerspace (Florida USA)**: 6 events
- **Melbourne Red Hat User Group**: 2 events
- **Space Coast Devs**: 2 events
- **SpaceCoastSec - Space Coast's Information Security Community**: 2 events
- **Groundswell Startups: Space Coast**: 1 event

### 🔄 Changes
- Updated event listings from Meetup groups
- Events filtered for 2025-10
- Markdown formatted for Astro site integration
- Sorted chronologically by event date

### 🌐 Source Groups
- [Space Coast Devs](https://www.meetup.com/space-coast-devs/)
- [Space Coast Security](https://www.meetup.com/spacecoastsec)
- [Melbourne Makerspace](https://www.meetup.com/melbourne-makerspace-florida-usa/)
- [Melbourne R/H User Group](https://www.meetup.com/melbourne-rhug)
- [Startup Space Coast](https://www.meetup.com/startupspacecoast/)

*This PR was created automatically by the evnt-hndlr tool. Please review the content before merging.*