### PR TITLE
fix: make member search work after navigation

### DIFF
--- a/src/components/members/MemberCard.astro
+++ b/src/components/members/MemberCard.astro
@@ -25,6 +25,7 @@ const lookingForLabels: Record<string, string> = {
 
 <a
   href={`/members/${discordId}`}
+  data-search={`${displayName} ${skills.join(' ')}`.toLowerCase()}
   class="flex flex-col gap-3 p-5 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-slate-900 hover:shadow-lg hover:border-primary dark:hover:border-primary transition-all group"
 >
   <div class="flex items-center gap-3">

--- a/src/pages/members/index.astro
+++ b/src/pages/members/index.astro
@@ -97,15 +97,20 @@ members.sort((a, b) => a.displayName.localeCompare(b.displayName));
 </PageLayout>
 
 <script>
-  const search = document.getElementById('member-search') as HTMLInputElement | null;
-  const grid = document.getElementById('member-grid');
-  if (search && grid) {
+  function initMemberSearch() {
+    const search = document.getElementById('member-search') as HTMLInputElement | null;
+    const grid = document.getElementById('member-grid');
+    if (!search || !grid || search.dataset.bound) return;
+
+    search.dataset.bound = 'true';
     search.addEventListener('input', () => {
       const q = search.value.toLowerCase().trim();
       grid.querySelectorAll<HTMLAnchorElement>('a[href^="/members/"]').forEach((card) => {
-        const text = card.textContent?.toLowerCase() ?? '';
-        card.style.display = !q || text.includes(q) ? '' : 'none';
+        card.style.display = !q || card.dataset.search?.includes(q) ? '' : 'none';
       });
     });
   }
+
+  initMemberSearch();
+  document.addEventListener('astro:page-load', initMemberSearch);
 </script>


### PR DESCRIPTION
### Problem
Member search stops working after navigating away from the directory and back. It also only searches the skills visible on each card.


https://github.com/user-attachments/assets/a76857ed-6d47-41a4-8efd-99bc991fe249



### How to reproduce
Open the member directory, navigate away and back, then try searching.

### Fix
Rebind search after Astro page navigation and include all member skills in the searchable data. Note that this PR was largely AI-assisted, and I do not have much experience personally with Astro. 