### PR TITLE
Add Space Coast Tech Events for August 2026

### DIFF
--- a/src/content/post/space-coast-tech-events-2026-08.mdx
+++ b/src/content/post/space-coast-tech-events-2026-08.mdx
@@ -1,0 +1,213 @@
+---
+publishDate: 2026-08-01T00:00:00Z
+title: Space Coast Tech Events for August 2026
+excerpt: List of tech events around the Space Coast for August 2026.
+category: Events
+tags:
+  - meetups
+  - events
+slug: space-coast-tech-events-august-2026
+image: ~/assets/images/space-coast-devs-events.png
+---
+
+import CallToAction from '~/components/widgets/CallToAction.astro';
+
+## [Trust No Signal - Exploiting Digital Energy at Level 0](https://www.meetup.com/spacecoastsec/events/313526424/) via [SpaceCoastSec - Space Coast's Information Security Community](https://www.meetup.com/spacecoastsec)
+
+No packets. No exploits. Just physics. Newton never signed off on your threat model. Tesla would have exploited it. This presentation discusses cyber-physics transduction attacks where electromagnetic fields, acoustic resonance, and power supply noise can be chained to create a false digital reality—without touching a single line of code, firmware, or network protocol. These physics-originating, cross-domain attacks operate at the foundational Purdue Level 0, weaponizing "digital energy" to manipulate the flow from atoms to bits. By compromising the physics of the sensing or actuator device, an adversary can create malicious cyber effects from spoofed telemetry to catastrophic mechanical failure while completely bypassing Zero Trust, encryption, and traditional threat models. It is time to secure the physics.
+
+Bio
+
+Paul is a Cyber SME at nou Systems, Inc. His expertise includes space systems, service provider, and ICS/SCADA network infrastructure attacks and defenses, as well as large complex network design and implementation. He has a BS in Math\\Computer Science, a MS in Space Systems, a MS in Systems Management, a MS in Information Assurance and Security and a MS in Computer Information Systems. In addition, he holds numerous industry network and security certifications.
+
+Join SpaceCoastSec at 6:30PM EST for an in-person gathering of local cybersecurity professionals, enthusiasts, and curious learners. Each meetup features a speaker discussing a timely infosec topic, as well as open discussion time before and after the presentation for casual banter and friendly networking. Our sessions are informal, inclusive, and completely free—no matter your experience level or background. Come learn, share ideas, ask questions, and stay updated on the latest trends in cybersecurity as part of Brevard County’s growing information security community.
+
+Our monthly in-person meetups are held on the 2nd floor of Building 17 on the EFSC Melbourne campus unless otherwise stated here on Meetup.
+
+- **Date:** Aug 12
+- **Time:** 6:30 PM Bending Spoons
+- **Group:** [SpaceCoastSec - Space Coast's Information Security Community](https://www.meetup.com/spacecoastsec)
+
+## [Food Truck Friday - The Best Caribbean Food](https://www.meetup.com/startupspacecoast/events/315860232/) via [Groundswell Startups: Space Coast](https://www.meetup.com/startupspacecoast/)
+
+Join us for our weekly Food Truck Friday! It's a great way to get to know our community of tech-focused, highly-skilled professionals, and connect with the startup ecosystem on The Space Coast.
+
+Stop by, enjoy a bite and a brew, and check out what's happening on Irwin St.
+
+- **Date:** Aug 14
+- **Time:** 11:00 AM Bending Spoons
+- **Group:** [Groundswell Startups: Space Coast](https://www.meetup.com/startupspacecoast/)
+
+## [Food Truck Friday - A Pinch of Rodriguez](https://www.meetup.com/startupspacecoast/events/313315663/) via [Groundswell Startups: Space Coast](https://www.meetup.com/startupspacecoast/)
+
+Join us for our weekly Food Truck Friday! It's a great way to get to know our community of tech-focused, highly-skilled professionals, and connect with the startup ecosystem on The Space Coast.
+
+Stop by, enjoy a bite and a brew, and check out what's happening on Irwin St.
+
+- **Date:** Aug 21
+- **Time:** 11:00 AM Bending Spoons
+- **Group:** [Groundswell Startups: Space Coast](https://www.meetup.com/startupspacecoast/)
+
+## Open House: Electronics Projects and Programming via [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
+
+Want to learn basic electronics? Interested in working with a microcontroller, like the arduino, ESP32, or the Raspberry Pi Pico? Need help designing your own PCB? Want to learn to program in Python? Or do you just want to find out more about the Makerspace (and take a tour)? All you have to do is stop by the open house and ask, and someone will be happy to work with you.
+
+The open house is generally unstructured. It has been more effective to work with people 1 on 1. That way people can start, and continue, learning at their own pace.
+
+(Picture courtesy of Wikimedia Commons)
+
+- **Recurring:** Every week on Saturday
+- **Group:** [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
+
+**Upcoming Dates:**
+
+- [Sat, Aug 1 at 10:00 AM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/315653449/)
+- [Sat, Aug 8 at 10:00 AM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/315748293/)
+- [Sat, Aug 15 at 10:00 AM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/315844578/)
+- [Sat, Aug 22 at 10:00 AM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/)
+- [Sat, Aug 29 at 10:00 AM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/)
+
+## Open House: Wood Turning via [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
+
+Learn to Turn! Someone will show you how to turn wood safely on a lathe & which tools you should use. You can turn spindles, pens, bowls, or a wide variety of other items. Or do you just want to find out more about the Makerspace (and take a tour)? All you have to do is stop by the open house and ask, and someone will be happy to work with you.  
+The open house is generally unstructured. It has been more effective to work with people 1 on 1. That way people can start, and continue, learning at their own pace.
+
+Original Image provided by Grwoodturning on WikiMedia:  
+[https://commons.wikimedia.org/wiki/File:Bowl_turning.jpg](https://commons.wikimedia.org/wiki/File:Bowl_turning.jpg)
+
+- **Recurring:** Every week on Saturday until January 1, 2028
+- **Group:** [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
+
+**Upcoming Dates:**
+
+- [Sat, Aug 1 at 10:00 AM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/315653371/)
+- [Sat, Aug 8 at 10:00 AM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/315748210/)
+- [Sat, Aug 15 at 10:00 AM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/315844509/)
+- [Sat, Aug 22 at 10:00 AM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/)
+- [Sat, Aug 29 at 10:00 AM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/)
+
+## Wood Shop via [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
+
+Free and open to the public! This is the time to come and learn woodworking, power tools like the band saw, table saw, drill press, sanders, etc. We even have a CNC! Want to fix a broken table leg? Build a shelf? Build a bird or bat house? Work on these projects and anything you imagine every week!
+
+Drop in a take a tour of the Makerspace to see what it's all about.
+
+- **Recurring:** Every week on Monday
+- **Group:** [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
+
+**Upcoming Dates:**
+
+- [Mon, Aug 3 at 7:00 PM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/315686903/)
+- [Mon, Aug 10 at 7:00 PM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/315781588/)
+- [Mon, Aug 17 at 7:00 PM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/315881447/)
+- [Mon, Aug 24 at 7:00 PM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/)
+- [Mon, Aug 31 at 7:00 PM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/)
+
+## Pottery via [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
+
+Free and open to the public, kids and adults! This is the time to come and develop your creative skills among friends. We've got tools and volunteers to help with all kinds of arts and crafts. Here are a few to get you thinking about what you'd like to try:
+
+- Pottery - Hand built, Slab rolling, or Wheel thrown
+- Sewing - Embroidery, Serger, Quilting
+- Painting - Acrylic, Water color, Oil
+- Card Making
+- Jewelry
+- Origami
+- Yarn - Knit or Crochet
+
+Bring in a project you're working on or an idea of what you'd like to try and we'll do what we can to help bring it to life.  
+Lately, we've been spending most of the open house in the pottery studio and above are some of our creations.
+
+- **Recurring:** Every week on Monday
+- **Group:** [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
+
+**Upcoming Dates:**
+
+- [Mon, Aug 3 at 7:00 PM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/315687087/)
+- [Mon, Aug 10 at 7:00 PM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/315781743/)
+- [Mon, Aug 17 at 7:00 PM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/315881604/)
+- [Mon, Aug 24 at 7:00 PM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/)
+- [Mon, Aug 31 at 7:00 PM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/)
+
+## AI Hands-On Workshop via [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
+
+Join us for our AI Workshop, where we dive into hands-on projects that bring AI to life!
+
+Each session, we’ll work on activities like:  
+Vibe Coding Apps  
+Using AI in Creative Projects  
+Generate 3D Models to be 3D Printed  
+Generate Images to be Laser Cut
+
+Whether you’re a beginner or experienced, you’ll get the chance to collaborate, create, and explore the endless possibilities of AI in the maker world.
+
+- **Recurring:** Every week on Tuesday until December 28, 2027
+- **Group:** [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
+
+**Upcoming Dates:**
+
+- [Tue, Aug 4 at 7:00 PM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/315700701/)
+- [Tue, Aug 11 at 7:00 PM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/315796471/)
+- [Tue, Aug 18 at 7:00 PM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/315896543/)
+- [Tue, Aug 25 at 7:00 PM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/)
+
+## Open House: Metalshop via [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
+
+Free and open to the public!
+
+Want to find out how to work with a milling machine, a lathe, or other metalworking tools? Do you need help with a small project? Would you like to tour the space and find out more about what the Makerspace has to offer? Our Open House volunteers would be glad to help!
+
+- **Recurring:** Every week on Tuesday until December 19, 2026
+- **Group:** [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
+
+**Upcoming Dates:**
+
+- [Tue, Aug 4 at 7:00 PM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/315700785/)
+- [Tue, Aug 11 at 7:00 PM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/315796552/)
+- [Tue, Aug 18 at 7:00 PM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/315896633/)
+- [Tue, Aug 25 at 7:00 PM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/)
+
+## Open House: 3D Printing via [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
+
+FREE and open to the public of all ages! This is the time to come and learn how to use the 3D printer; as well as how to obtain or create files to run on them. The 3D printer has a nominal charge of 5 cents per gram for the filament it consumes; but larger projects you may want to obtain 3D filament of your own. Generally, 1 Kgram of 1.75 mm PLA filament is the most common used by many of our members.
+
+- **Recurring:** Every week on Thursday
+- **Group:** [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
+
+**Upcoming Dates:**
+
+- [Thu, Aug 6 at 7:00 PM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/315728761/)
+- [Thu, Aug 13 at 7:00 PM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/315825561/)
+- [Thu, Aug 20 at 7:00 PM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/315926449/)
+- [Thu, Aug 27 at 7:00 PM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/)
+
+## Open House: Laser Cutting via [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
+
+Want to learn how to use a laser cutter? Have something you need engraved or laser cut? Need to figure out your new tabletop, laser engraver? Check out our open house! It's free and open to the public of all ages!
+
+We use a 100-watt CO2 laser cutter with a Ruida 644XG controller. (More information can be found [here](https://wiki.melbournemakerspace.org/Laser%20Cutter).) It can cut paper, fabric, and up to 1/4" in wood or laser-safe acrylic. There is some scrap material available for use free of charge, but if you have a bigger project, you will need to bring in material to use.
+
+We use Lightburn software to control the laser. It can read most of the standard graphic and vector file types including .bmp, .jpg, .ai, .dxf, and .svg.
+
+- **Recurring:** Every week on Thursday until December 18, 2026
+- **Group:** [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
+
+**Upcoming Dates:**
+
+- [Thu, Aug 6 at 7:00 PM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/315729241/)
+- [Thu, Aug 13 at 7:00 PM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/315826064/)
+- [Thu, Aug 20 at 7:00 PM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/315926949/)
+- [Thu, Aug 27 at 7:00 PM](https://www.meetup.com/melbourne-makerspace-florida-usa/events/)
+
+## Space Coast Devs Monthly Meetup via [Space Coast Devs](https://www.meetup.com/space-coast-devs/)
+
+Join us every third Wednesday at Protowork Studio Hangout from 6:00 PM to 8:00 PM. The first hour is casual networking, followed by a light presentation or two, community lightning talks, tech topics, or project updates.
+
+6:00 PM - 7:00 PM: casual networking | 7:00 PM - 8:00 PM: talks and project updates
+
+- **Recurring:** Every 3rd Wednesday of the month until January 10, 2027
+- **Group:** [Space Coast Devs](https://www.meetup.com/space-coast-devs/)
+
+**Upcoming Dates:**
+
+- [Wed, Aug 19 at 6:00 PM](https://www.meetup.com/space-coast-devs/events/315911269/)


### PR DESCRIPTION
## Summary

- add the August 2026 Space Coast tech events post
- generated from current Meetup listings with an explicit `2026-08` target

## Validation

- `npm run check`

The post title, excerpt, slug, and all listed event dates are August 2026.