### PR TITLE
Stage only generated event post

### DIFF
--- a/.github/workflows/update-events.yaml
+++ b/.github/workflows/update-events.yaml
@@ -65,6 +65,7 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ github.token }}
+          add-paths: ${{ env.TARGET_FILE }}
           commit-message: "Update events for ${{ env.TARGET_MONTH }}"
           title: "Update Space Coast Tech Events for ${{ env.TARGET_MONTH }}"
           body: |

--- a/.github/workflows/update-events.yaml
+++ b/.github/workflows/update-events.yaml
@@ -44,6 +44,11 @@ jobs:
           npm ci
           npm run build
 
+      - name: Install site dependencies
+        run: |
+          corepack enable
+          pnpm install --frozen-lockfile
+
       - name: Compute target month
         run: |
           TARGET_MONTH="${{ inputs.target_month }}"
@@ -60,6 +65,7 @@ jobs:
       - name: Generate markdown into site repo
         run: |
           node tools/evnthndlr/dist/generate.js --month="${TARGET_MONTH}" --file="${TARGET_FILE}"
+          pnpm exec prettier --write "$TARGET_FILE"
 
       - name: Create or update PR
         uses: peter-evans/create-pull-request@v7


### PR DESCRIPTION
## Summary

Restrict the event workflow's `create-pull-request` step to the generated post file.

## Why

The temporary `tools/evnthndlr` checkout was being staged as a gitlink, which caused deployment builds to fail because it is not a configured submodule.

## Validation

- Prettier check for the workflow
- workflow YAML parsed successfully