### PR TITLE
Update Space Coast Tech Events for 2026-08 (#23)

### DIFF
--- a/.github/workflows/update-events.yaml
+++ b/.github/workflows/update-events.yaml
@@ -59,12 +59,17 @@ jobs:
             echo "target_month must use YYYY-MM format" >&2
             exit 1
           fi
+          TARGET_DATE="${TARGET_MONTH}-01"
+          TARGET_YEAR="${TARGET_MONTH%-*}"
+          TARGET_MONTH_NAME="$(date -u -d "$TARGET_DATE" +%B | tr '[:upper:]' '[:lower:]')"
           echo "TARGET_MONTH=$TARGET_MONTH" >> $GITHUB_ENV
-          echo "TARGET_FILE=src/content/post/space-coast-tech-events-$TARGET_MONTH.mdx" >> $GITHUB_ENV
+          echo "TARGET_FILE=src/content/post/$TARGET_DATE-space-coast-tech-events-$TARGET_MONTH_NAME-$TARGET_YEAR.mdx" >> $GITHUB_ENV
 
       - name: Generate markdown into site repo
         run: |
           node tools/evnthndlr/dist/generate.js --month="${TARGET_MONTH}" --file="${TARGET_FILE}"
+          # Meetup page titles can append the platform owner to the parsed time.
+          sed -i -E 's/(\*\*Time:\*\*.*) Bending Spoons$/\1/' "$TARGET_FILE"
           pnpm exec prettier --write "$TARGET_FILE"
 
       - name: Create or update PR

--- a/src/content/post/2026-08-01-space-coast-tech-events-august-2026.mdx
+++ b/src/content/post/2026-08-01-space-coast-tech-events-august-2026.mdx
@@ -12,6 +12,20 @@ image: ~/assets/images/space-coast-devs-events.png
 
 import CallToAction from '~/components/widgets/CallToAction.astro';
 
+## [Space Coast AI Town Hall](https://luma.com/x62nsa0h) via [The AI Collective](https://luma.com/genai-collective)
+
+The AI Collective is building the human layer for the AI era — and our Space Coast chapter is bringing that conversation home.
+Join us for a free community Town Hall at the Catherine Schweinsberg Rood Central Library: an open, human-centered conversation about what AI actually means for your life, your work, and your ideas.
+Whether you're AI-curious, running a business, early in your career, or just darn curious, there's a seat for you. No jargon, no sales pitch — just honest dialogue, real questions, and shared curiosity, from practical everyday wins to the cybersecurity questions on everyone's mind.
+Hosted by four locals who live this work:
+Stephen Ghigliotty (AI educator) moderating, with Jurgen Schwanitz (ACT Computers), Mike Marks (semi-retired consultant; teaches AI and critical thinking at Florida Tech and Purdue), and Wendi Jo Bost (Brevard County Library Services Director; Welcome & Why libraries).
+Come curious, bring your questions, connect with people from across the Space Coast, and leave more confident — and better connected. All are welcome — no tech background needed.
+Brought to you in collaboration with Brevard County Libraries.
+
+- **Date:** Thu, Aug 6
+- **Time:** 5:30 PM
+- **Group:** [The AI Collective](https://luma.com/genai-collective)
+
 ## [Trust No Signal - Exploiting Digital Energy at Level 0](https://www.meetup.com/spacecoastsec/events/313526424/) via [SpaceCoastSec - Space Coast's Information Security Community](https://www.meetup.com/spacecoastsec)
 
 No packets. No exploits. Just physics. Newton never signed off on your threat model. Tesla would have exploited it. This presentation discusses cyber-physics transduction attacks where electromagnetic fields, acoustic resonance, and power supply noise can be chained to create a false digital reality—without touching a single line of code, firmware, or network protocol. These physics-originating, cross-domain attacks operate at the foundational Purdue Level 0, weaponizing "digital energy" to manipulate the flow from atoms to bits. By compromising the physics of the sensing or actuator device, an adversary can create malicious cyber effects from spoofed telemetry to catastrophic mechanical failure while completely bypassing Zero Trust, encryption, and traditional threat models. It is time to secure the physics.
@@ -24,8 +38,8 @@ Join SpaceCoastSec at 6:30PM EST for an in-person gathering of local cybersecuri
 
 Our monthly in-person meetups are held on the 2nd floor of Building 17 on the EFSC Melbourne campus unless otherwise stated here on Meetup.
 
-- **Date:** Aug 12
-- **Time:** 6:30 PM Bending Spoons
+- **Date:** Wed, Aug 12
+- **Time:** 6:30 PM
 - **Group:** [SpaceCoastSec - Space Coast's Information Security Community](https://www.meetup.com/spacecoastsec)
 
 ## [Food Truck Friday - The Best Caribbean Food](https://www.meetup.com/startupspacecoast/events/315860232/) via [Groundswell Startups: Space Coast](https://www.meetup.com/startupspacecoast/)
@@ -34,9 +48,17 @@ Join us for our weekly Food Truck Friday! It's a great way to get to know our co
 
 Stop by, enjoy a bite and a brew, and check out what's happening on Irwin St.
 
-- **Date:** Aug 14
-- **Time:** 11:00 AM Bending Spoons
+- **Date:** Fri, Aug 14
+- **Time:** 11:00 AM
 - **Group:** [Groundswell Startups: Space Coast](https://www.meetup.com/startupspacecoast/)
+
+## [NETWORK LAUNCH - FLORIDA'S SPACE COAST (August 2026)](https://www.eventbrite.com/e/network-launch-floridas-space-coast-august-2026-tickets-1986762724792) via [Network Launch](https://www.eventbrite.com/o/network-launch-107498260021)
+
+Network Launch connects the military and civilian communities through accessible networking events.
+
+- **Date:** Tue, Aug 18
+- **Time:** 5:30 PM
+- **Group:** [Network Launch](https://www.eventbrite.com/o/network-launch-107498260021)
 
 ## [Food Truck Friday - A Pinch of Rodriguez](https://www.meetup.com/startupspacecoast/events/313315663/) via [Groundswell Startups: Space Coast](https://www.meetup.com/startupspacecoast/)
 
@@ -44,9 +66,17 @@ Join us for our weekly Food Truck Friday! It's a great way to get to know our co
 
 Stop by, enjoy a bite and a brew, and check out what's happening on Irwin St.
 
-- **Date:** Aug 21
-- **Time:** 11:00 AM Bending Spoons
+- **Date:** Fri, Aug 21
+- **Time:** 11:00 AM
 - **Group:** [Groundswell Startups: Space Coast](https://www.meetup.com/startupspacecoast/)
+
+## [ISC2 Florida SpaceCoast Chapter Meeting - August 2026](https://www.eventbrite.com/e/isc2-florida-spacecoast-chapter-meeting-august-2026-tickets-1992883622562) via [ISC2 Florida SpaceCoast Chapter](https://www.eventbrite.com/o/isc2-florida-spacecoast-chapter-72982354203)
+
+Join us for the August ISC2 SpaceCoast Chapter Meeting, where cybersecurity professionals gather to network, learn, & share insights.
+
+- **Date:** Tue, Aug 25
+- **Time:** 6:30 PM
+- **Group:** [ISC2 Florida SpaceCoast Chapter](https://www.eventbrite.com/o/isc2-florida-spacecoast-chapter-72982354203)
 
 ## Open House: Electronics Projects and Programming via [Melbourne Makerspace (Florida USA)](https://www.meetup.com/melbourne-makerspace-florida-usa/)
 


### PR DESCRIPTION
* Update events for 2026-08

* Remove accidental event generator gitlink

* Format refreshed August event post

* Refactor event generation workflow and update event markdown for August 2026

* Update event dates and add new networking event for August 2026

---------